### PR TITLE
Update build.gradle.kts to make it compatible for newer versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,8 @@ intellij {
     version.set(properties("platformVersion"))
     type.set(properties("platformType"))
 
+    updateSinceUntilBuild.set(false)
+
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
 }


### PR DESCRIPTION
Solving #24 

I have provided a gradle configuration inside `build.gradle.kts` to make this plugin compatible with upcoming IDE versions so you do not have to manually applying version to `version.set(properties("platformVersion"))` each time.

Same issue has been faced with my plugin "[Jumping Lines](https://plugins.jetbrains.com/plugin/22878-jumping-lines)" too. You can see commit [here](https://github.com/HarshPanchal18/Jumping-Lines/commit/49113f1e3cac0307477aa7bbd0587cb470a37044#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06) as well.

I have asked an author of plugin [IntelliJ-Inspection-Lens](https://github.com/chylex/IntelliJ-Inspection-Lens). He suggested this solution which worked out for me.

Hope this helps with you too.

- [Doc Reference](https://plugins.jetbrains.com/docs/intellij/configuring-plugin-project.html#patching-the-plugin-configuration-file)